### PR TITLE
PE-111: BT Prebid Adapter can request AA ads or regular ads

### DIFF
--- a/modules/BTBidAdapter.js
+++ b/modules/BTBidAdapter.js
@@ -31,7 +31,7 @@ function imp(buildImp, bidRequest, context) {
 
   if (params) {
     const { siteId, ab, ...btBidParams } = params;
-    Object.assign(imp, { ext: btBidParams, siteId, ab });
+    Object.assign(imp, { ext: btBidParams });
   }
   if (ortb2Imp?.ext.gpid) {
     deepSetValue(imp, 'gpid', ortb2Imp.ext.gpid);
@@ -51,6 +51,12 @@ function imp(buildImp, bidRequest, context) {
  */
 function request(buildRequest, imps, bidderRequest, context) {
   const request = buildRequest(imps, bidderRequest, context);
+  const { params } = bidderRequest.bids?.[0] || {};
+
+  if (params) {
+    const { ab, siteId } = params;
+    deepSetValue(request, 'site.ext.blockthrough', { ab, siteId });
+  }
   if (config.getConfig('debug')) {
     request.test = 1;
   }

--- a/test/spec/modules/BTBidAdapte_spec.js
+++ b/test/spec/modules/BTBidAdapte_spec.js
@@ -89,8 +89,8 @@ describe('BT Bid Adapter', () => {
       expect(requests[0].url).to.equal(ENDPOINT_URL);
       expect(requests[0].data).to.exist;
       expect(requests[0].data.imp[0].ext).to.deep.equal(bidderParams);
-      expect(requests[0].data.imp[0].ab).to.be.true;
-      expect(requests[0].data.imp[0].siteId).to.equal('55555');
+      expect(requests[0].data.site.ext.blockthrough.ab).to.be.true;
+      expect(requests[0].data.site.ext.blockthrough.siteId).to.equal('55555');
     });
   });
 


### PR DESCRIPTION
## Story

[PE-111](https://blockthrough.atlassian.net/browse/PE-111)

Move site specific parameters to the `site.ext.blockthrough`
## Testing

What tests did you perform to ensure that this code functions as expected?

- [x] Manual testing 
- [ ] Unit tests
- [ ] Integration tests
- [ ] A/B tests 





[PE-111]: https://blockthrough.atlassian.net/browse/PE-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ