### PR TITLE
BP-79: Send GPID as a part of `imp[].ext`

### DIFF
--- a/modules/BTBidAdapter.js
+++ b/modules/BTBidAdapter.js
@@ -34,7 +34,7 @@ function imp(buildImp, bidRequest, context) {
   if (params) {
     deepSetValue(imp, 'ext', params);
   }
-  if (ortb2Imp?.ext.gpid) {
+  if (ortb2Imp?.ext?.gpid) {
     deepSetValue(imp, 'ext.gpid', ortb2Imp.ext.gpid);
   }
 

--- a/modules/BTBidAdapter.js
+++ b/modules/BTBidAdapter.js
@@ -35,7 +35,7 @@ function imp(buildImp, bidRequest, context) {
     deepSetValue(imp, 'ext', params);
   }
   if (ortb2Imp?.ext.gpid) {
-    deepSetValue(imp, 'gpid', ortb2Imp.ext.gpid);
+    deepSetValue(imp, 'ext.gpid', ortb2Imp.ext.gpid);
   }
 
   return imp;


### PR DESCRIPTION
[BP-79](https://blockthrough.atlassian.net/browse/BP-79)

up-prebid.js [PR](https://github.com/blockthrough/up-prebid.js/pull/149)

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->


[BP-79]: https://blockthrough.atlassian.net/browse/BP-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ