### PR TITLE
BP-139: Send Blockthrough Metadata in query params

### DIFF
--- a/modules/BTBidAdapter.js
+++ b/modules/BTBidAdapter.js
@@ -55,6 +55,11 @@ function request(buildRequest, imps, bidderRequest, context) {
     name: 'pbjs',
     version: '$prebid.version$',
   });
+  deepSetValue(
+    request,
+    'site.ext.blockthrough.ab',
+    !!bidderRequest.ortb2.site.ext.blockthrough.ab
+  );
 
   if (window.location.href.includes('btServerTest=true')) {
     request.test = 1;
@@ -107,10 +112,18 @@ function buildRequests(validBidRequests, bidderRequest) {
     bidderRequest,
   });
 
+  const endpointUrl = new URL(ENDPOINT_URL);
+  const { ab, orgID, websiteID } = data.site.ext.blockthrough;
+
+  endpointUrl.searchParams.set('ab', ab);
+  endpointUrl.searchParams.set('orgID', orgID);
+  endpointUrl.searchParams.set('websiteID', websiteID);
+  endpointUrl.searchParams.set('pbjsVersion', '$prebid.version$');
+
   return [
     {
       method: 'POST',
-      url: ENDPOINT_URL,
+      url: endpointUrl.href,
       data,
       bids: validBidRequests,
     },

--- a/test/spec/modules/BTBidAdapter_spec.js
+++ b/test/spec/modules/BTBidAdapter_spec.js
@@ -17,6 +17,8 @@ import 'modules/schain.js';
 
 describe('BT Bid Adapter', () => {
   const ENDPOINT_URL = 'https://pbs.btloader.com/openrtb2/auction';
+  const orgID = '4829301576428910';
+  const websiteID = '5654012389765432';
   const validBidRequests = [
     {
       bidId: '2e9f38ea93bb9e',
@@ -35,6 +37,16 @@ describe('BT Bid Adapter', () => {
     bidderCode: 'blockthrough',
     bidderRequestId: 'test-bidder-request-id',
     bids: validBidRequests,
+    ortb2: {
+      site: {
+        ext: {
+          blockthrough: {
+            orgID,
+            websiteID,
+          },
+        },
+      },
+    },
   };
 
   describe('isBidRequestValid', function () {
@@ -76,11 +88,16 @@ describe('BT Bid Adapter', () => {
           pubId: '11111',
         },
       };
+      const expectedEndpointUrl = new URL(ENDPOINT_URL);
+      expectedEndpointUrl.searchParams.set('ab', 'false');
+      expectedEndpointUrl.searchParams.set('orgID', orgID);
+      expectedEndpointUrl.searchParams.set('websiteID', websiteID);
+      expectedEndpointUrl.searchParams.set('pbjsVersion', '$prebid.version$');
 
       const requests = spec.buildRequests(validBidRequests, bidderRequest);
 
       expect(requests[0].method).to.equal('POST');
-      expect(requests[0].url).to.equal(ENDPOINT_URL);
+      expect(requests[0].url).to.equal(expectedEndpointUrl.href);
       expect(requests[0].data).to.exist;
       expect(requests[0].data.ext.prebid.channel).to.deep.equal({
         name: 'pbjs',


### PR DESCRIPTION
## Story

[BP-139](https://blockthrough.atlassian.net/browse/BP-139)

- send BT metadata in query params
- explicitly set `ab` flag, so that publishers won't have to set it in their `bidderConfig`

Corresponding [up-prebid.js PR](https://github.com/blockthrough/up-prebid.js/pull/161)

## Testing

What tests did you perform to ensure that this code functions as expected?

- [x] Manual testing (describe)
- [ ] Unit tests
- [ ] Integration tests
- [ ] A/B tests (describe and don't forget to post to [#a-b-testing](https://blockthrough.slack.com/archives/C032S7C8X7C))

[BP-139]: https://blockthrough.atlassian.net/browse/BP-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ